### PR TITLE
main manager spawning & basic enemy health

### DIFF
--- a/Assets/Scripts/Enemy.cs
+++ b/Assets/Scripts/Enemy.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 
 public class Enemy : MonoBehaviour
 {
+    private float health = 1;
     // Start is called once before the first execution of Update after the MonoBehaviour is created
     void Start()
     {
@@ -11,6 +12,8 @@ public class Enemy : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        
+        if(health < 0){
+            Destroy(gameObject);
+        }
     }
 }

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -4,16 +4,37 @@ public class GameManager : MonoBehaviour
 {
     public GameObject enemy;
     public int enemyCount;
+    public float playableSpace = 0.9f;
+    public Camera playerCam;
 
     // Start is called once before the first execution of Update after the MonoBehaviour is created
     void Start()
     {
-        
+        for(int i = 0; i < enemyCount; i++) {
+            SpawnEnemySomewhere();
+        }
     }
 
     // Update is called once per frame
     void Update()
     {
         
+    }
+
+    public void SpawnEnemySomewhere(){
+
+        //get the ranges by getting the playspace, then halving it to get one half of each axis
+        //range
+        float x = (Screen.width * playableSpace);
+        float y = (Screen.height * playableSpace);
+
+        
+
+
+        Instantiate(enemy, playerCam.ScreenToWorldPoint(new Vector3(Random.Range(0, x),
+                                                         Random.Range(0, y), 1))
+                            , Quaternion.identity);
+
+        return;
     }
 }

--- a/README.md
+++ b/README.md
@@ -13,5 +13,6 @@ Required features:
     Enemies are destroyed if they touch the Hero (arrow)
     Enemies lose 20% of their health, their alpha value becomes 80% of their previous value, when they collide with an egg. The 4th collision with an egg destroys the enemy. 
     When enemies are destroyed, they respawn at a random point at 90% os screen boundaries
+      DONE
     Application status is displayed: Hero Mode, Number of eggs, Enemy count, Enemies Destroyed
     Key-Q quits or Pauses the application


### PR DESCRIPTION
main manger now has a function to spawn an enemy within a specified margin percentage.

enemy has a basic float to rep health. which it checks each frame. if its less than 0